### PR TITLE
V1.0.0 re

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go run cmd/manager/main.go --canary <CANARY-BATCH-SIZE> --target-label <EXISTING
 ```
 
 ## How to plug your tests in?
-A part from some basic checks regarding the status of the resources it deploys for you, Streamline does not define validating test for you resources. That responsibility is yours.\
+A part from some basic checks regarding the status of the resources it deploys for you, Rooster does not define validating test for you resources. That responsibility is yours.\
 Nonetheless, Rooster would execute a properly compiled Golang test binary and return the output in the command line.\
 To use your specific test, please do the following:\
 1. build your test file
@@ -57,6 +57,6 @@ go test -v rooster/pkg/tests
 * Consider keeping backup files in a more reliable & available location: bitbucket, s3, etc...
 * Improve the support for multiple daemonsets. So far multiple daemonsets can be released at once, as long as they define the same labels in their affinity context.
 * ~~Validate the canary-label by making sure it does not exist on any node in the cluster before going any further (Early failure policy).~~
-* Idempotency, deterministic behavior. Rooster will be run as a controller from inside the cluster, as operator/controller, in the future. (same idea of deployment-controller over replicaset. streamlinear can work as a controller for daemonset)
+* Idempotency, deterministic behavior. Rooster will be run as a controller from inside the cluster, as operator/controller, in the future. (same idea of deployment-controller over replicaset. Rooster can work as a controller for daemonset)
 * Improve the backup folder logic, and set backup files to be kept in different folders, based off the date, cluster name, etc...
 * Add the ability to trigger a rollback on demand

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ func main() {
 
 func defineRevertNeed() bool {
 	var response string
-	fmt.Println("Should Streamliner revert the recent changes? (y/n)")
+	fmt.Println("Should Rooster revert the recent changes? (y/n)")
 	fmt.Scanln(&response)
 	return strings.EqualFold(response, "Y")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/tests/kubernetes_client_test.go
+++ b/pkg/tests/kubernetes_client_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/tests/utils_test.go
+++ b/pkg/tests/utils_test.go
@@ -12,7 +12,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type StreamlinerUtilsTest struct {
+type RoosterUtilsTest struct {
 	suite.Suite
 }
 
@@ -30,13 +30,13 @@ type plural struct {
 	Resource string
 }
 
-func (suite *StreamlinerUtilsTest) SetupSuite() {
+func (suite *RoosterUtilsTest) SetupSuite() {
 	fmt.Println(" SetupSuite")
 	customDeleteOptions.DryRun = append(customDeleteOptions.DryRun, "All")
 	fmt.Printf("customDeleteOptions: %v\n", customDeleteOptions)
 }
 
-func (suite *StreamlinerUtilsTest) TestGroupVersionGuess() {
+func (suite *RoosterUtilsTest) TestGroupVersionGuess() {
 	apiVersion := "v1"
 	kind := "pod"
 	expectedResult := plural{}
@@ -50,7 +50,7 @@ func (suite *StreamlinerUtilsTest) TestGroupVersionGuess() {
 	assert.Equal(suite.T(), expectedResult.Resource, val.Resource)
 }
 
-func (suite *StreamlinerUtilsTest) TestShellScript() {
+func (suite *RoosterUtilsTest) TestShellScript() {
 	cmd := "pwd"
 	result, err := utils.Shell(cmd)
 	assert.Nil(suite.T(), err)
@@ -58,7 +58,7 @@ func (suite *StreamlinerUtilsTest) TestShellScript() {
 	assert.Contains(suite.T(), result, "Rooster/pkg/tests")
 }
 
-func (suite *StreamlinerUtilsTest) TestDeleteService() {
+func (suite *RoosterUtilsTest) TestDeleteService() {
 	m, err := utils.New("")
 	assert.Nil(suite.T(), err)
 	// Get services
@@ -74,7 +74,7 @@ func (suite *StreamlinerUtilsTest) TestDeleteService() {
 	assert.Nil(suite.T(), err)
 }
 
-func (suite *StreamlinerUtilsTest) TestDeleteServiceAccount() {
+func (suite *RoosterUtilsTest) TestDeleteServiceAccount() {
 	m, err := utils.New("")
 	assert.Nil(suite.T(), err)
 	// Get service accounts
@@ -90,7 +90,7 @@ func (suite *StreamlinerUtilsTest) TestDeleteServiceAccount() {
 	assert.Nil(suite.T(), err)
 }
 
-func (suite *StreamlinerUtilsTest) TestDeleteConfigMap() {
+func (suite *RoosterUtilsTest) TestDeleteConfigMap() {
 	m, err := utils.New("")
 	assert.Nil(suite.T(), err)
 	// Get config maps
@@ -106,7 +106,7 @@ func (suite *StreamlinerUtilsTest) TestDeleteConfigMap() {
 	assert.Nil(suite.T(), err)
 }
 
-func (suite *StreamlinerUtilsTest) TestDeleteDaemonSet() {
+func (suite *RoosterUtilsTest) TestDeleteDaemonSet() {
 	m, err := utils.New("")
 	assert.Nil(suite.T(), err)
 	// Get daemon sets
@@ -122,12 +122,12 @@ func (suite *StreamlinerUtilsTest) TestDeleteDaemonSet() {
 	assert.Nil(suite.T(), err)
 }
 
-func (suite *StreamlinerUtilsTest) TestCreate() {
+func (suite *RoosterUtilsTest) TestCreate() {
 	customCreateOptions := meta_v1.CreateOptions{}
 	customCreateOptions.DryRun = append(customCreateOptions.DryRun, "All")
 }
 
 func TestUtils(t *testing.T) {
-	s := new(StreamlinerUtilsTest)
+	s := new(RoosterUtilsTest)
 	suite.Run(t, s)
 }

--- a/pkg/tests/utils_test.go
+++ b/pkg/tests/utils_test.go
@@ -55,7 +55,7 @@ func (suite *StreamlinerUtilsTest) TestShellScript() {
 	result, err := utils.Shell(cmd)
 	assert.Nil(suite.T(), err)
 	assert.NotEmpty(suite.T(), result)
-	assert.Contains(suite.T(), result, "Open-Streamliner/pkg/tests")
+	assert.Contains(suite.T(), result, "Rooster/pkg/tests")
 }
 
 func (suite *StreamlinerUtilsTest) TestDeleteService() {

--- a/pkg/utils/crud_queries.go
+++ b/pkg/utils/crud_queries.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/utils/crud_verbs.go
+++ b/pkg/utils/crud_verbs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/utils/deployer_utils.go
+++ b/pkg/utils/deployer_utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/utils/k8sClient_config.go
+++ b/pkg/utils/k8sClient_config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/worker/deployer.go
+++ b/pkg/worker/deployer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/worker/manifest_files_handlers.go
+++ b/pkg/worker/manifest_files_handlers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/worker/query_handlers.go
+++ b/pkg/worker/query_handlers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/worker/test_endpoint.go
+++ b/pkg/worker/test_endpoint.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Streamliner Authors.
+Copyright 2023 The Rooster Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Rooster is an ambitious deployment tool targeting Kubernetes resources. In a canary fashion, resources can be deployed onto a Kubernetes cluster, and tested to ensure functionality.

### What it does
Streamliner deploys resources onto a cluster in a canary manner. It can also run custom tests that users can easily plug in by adding the test binaries. Once that is done, Streamliner picks up on the value given to the test related options indicated by the operator.

### Strong points
Tests to run can be customized. It's all left to the appreciation of the operator.
Progressive & automated rollout of resources
Ability to deploy multiple daemonSets at once
Unifying operation manuals from here onwards, as long as canary mode is involved.

### Limitations
Only Golang test binaries are accepted
Only 1 deployment configuration is supported, canary

### Future work

- Integration with Sentinel to automatically run indicated tests when rolling out.
- Automate the execution of Streamliner. Some ideas so far are to turn it into a Kubernetes Job, that will in turn do what it needs to, or integrate it into a Jenkins pipeline, triggered on demand, or automatically.
- Make the canary fashion optional. Allow Caas-Streamliner to deploy resources in different ways (all-at-once, canary-10Minutes, linear-10-Every-Minute, etc...)
- Accept other test binaries. Language-agnosticism is the goal.
- Add support for updates (updatePolicy: onDelete, and deletes pods?). Not just new releases but also existing resources being updated and released in a canary mode
- Consider keeping backup files in a more reliable & available location: bitbucket, s3, etc...
- Improve the support for multiple daemonsets. So far multiple daemonsets can be released at once, as long as they define the same labels in their affinity context.
- Idempotency, deterministic behavior. Streamliner will be run as a controller from inside the cluster, as operator/controller, in the future. (same idea of deployment-controller over replicaSet. Streamliner can work as a controller for daemonSet)
- Improve the backup folder logic, and set backup files to be kept in different folders, based off the date, cluster name, etc...
- Add the ability to trigger a rollback on demand